### PR TITLE
Corregir terminología y aclaraciones en el tema de Programación con objetos

### DIFF
--- a/docs/implementacion/oop.md
+++ b/docs/implementacion/oop.md
@@ -248,8 +248,7 @@ Y entre dos formas de heredar:
 El polimorfismo es el fenómeno por el que, al llamar a una operación de un
 objeto del que no se sabe su tipo específico, se ejecuta el método adecuado
 de acuerdo con su tipo real. Se basa en el **enlace dinámico** (*dynamic
-binding*): el método a ejecutar se elige en tiempo de ejecución, en función de
-la clase del objeto.
+binding*): el método a ejecutar se elige en tiempo de ejecución, en función del **tipo**  del objeto.
 
 ### Overriding
 
@@ -291,18 +290,18 @@ en una clase tienen precedencia sobre los de un `trait`.
 #### Ejemplo 2: un iterador con Scala traits
 
 ```scala
-trait Iterator[A] {
-  def hasNext: Boolean
-  def next(): A
+trait Iterador[A] {
+  def haySiguiente: Boolean
+  def siguiente(): A
 }
 
-class IntIterator(to: Int) extends Iterator[Int] {
-  private var current = 0
-  override def hasNext: Boolean = current < to
-  override def next(): Int = {
-    if (hasNext) {
-      val t = current
-      current += 1
+class IteradorEnteros(hasta: Int) extends Iterador[Int] {
+  private var actual = 0
+  override def haySiguiente: Boolean = actual < hasta
+  override def siguiente(): Int = {
+    if (haySiguiente) {
+      val t = actual
+      actual += 1
       t
     } else 0
   }
@@ -310,9 +309,9 @@ class IntIterator(to: Int) extends Iterator[Int] {
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val iterator = new IntIterator(10)
-    println(iterator.next()) // 0
-    println(iterator.next()) // 1
+    val iterador = new IteradorEnteros(10)
+    println(iterador.siguiente()) // 0
+    println(iterador.siguiente()) // 1
   }
 }
 ```
@@ -550,7 +549,7 @@ class Creador {
     PersonajeDeAccion[] x = {
         new PersonajeDeAccion(),
         new PersonajeDeAccion(),
-        new Heroe(),
+        new Heroe(), // Upcast implícito: se guarda como PersonajeDeAccion
         new PersonajeDeAccion()
     };
     return x;
@@ -561,7 +560,7 @@ public class Main {
   public static void main(String[] args) {
     PersonajeDeAccion[] cuatroFantasticos = new Creador().personajes();
     cuatroFantasticos[1].luchar();
-    cuatroFantasticos[2].luchar(); // Upcast, sin problema
+    cuatroFantasticos[2].luchar(); // Ya es un PersonajeDeAccion (upcast al crearlo)
 
     // En tiempo de compilación no existe el método volar() en PersonajeDeAccion:
     // cuatroFantasticos[2].volar();
@@ -697,9 +696,9 @@ Conviene distinguir dos ejes distintos:
 
 ¿El polimorfismo está ligado siempre a la herencia? No: también existe el
 **polimorfismo paramétrico**, mediante tipos genéricos (Ada, C++ *generics*,
-Java *templates* desde JDK 1.5, Scala...). Eso sí, con diferencias entre
+Java *generics* desde JDK 1.5, Scala...). Eso sí, con diferencias entre
 lenguajes: en C++ los genéricos permiten meta-programación en tiempo de
-compilación, mientras que en Java las plantillas son sobre todo *wrappers*
+compilación, mientras que en Java los generics son sobre todo *wrappers*
 que moldean objetos (*syntactic sugar*, por *type erasure*).
 
 ## Usos incorrectos de la herencia
@@ -803,6 +802,13 @@ class WithSpacesUppercaseWriter extends WithSpacesWriter {
 }
 ```
 
+Nótese que, para `"abc"`, ambas clases producen el mismo resultado
+(`"A B C"`): poner en mayúsculas y separar caracteres con espacios son
+operaciones que conmutan en este caso concreto. El problema que ilustran
+estas dos clases no es que el orden cambie el resultado, sino que hace falta
+una subclase distinta por cada combinación — y ese número crece
+combinatoriamente en cuanto aparece una forma de imprimir más.
+
 Y si aparece una **nueva** forma de imprimir (por ejemplo, con un *checksum*
 delante), hay que repetir la combinatoria para cada forma ya existente:
 
@@ -818,7 +824,11 @@ class ChecksumWriter extends ConsoleWriter {
 ```
 
 El resultado de seguir combinando así es una jerarquía de herencia que crece
-combinatoriamente y se vuelve inmanejable:
+combinatoriamente y se vuelve inmanejable. El diagrama extrapola cómo
+quedaría la jerarquía si se siguiera combinando `Uppercase`, `WithSpaces` y
+`Checksum` entre sí — no se ha mostrado en código cada una de esas
+combinaciones, solo las piezas sueltas (`UppercaseWriter`, `WithSpacesWriter`,
+`ChecksumWriter`) y dos combinaciones a modo de ejemplo:
 
 ![Jerarquía de herencia fuera de control entre las variantes de Writer](/img/implementacion/oop/writer-hierarchy.svg)
 
@@ -870,13 +880,19 @@ A B C
 
 Con *stackable traits*, cada combinación se construye **componiendo** traits
 en el momento de crear el objeto (`with Uppercase with WithSpaces`), en lugar
-de declarar una subclase nueva por cada combinación. En Scala, los `trait`
-normales son como interfaces y se enlazan en tiempo de ejecución (sin acceso
-a `super`); para poder llamar a `super` hace falta redefinirlos como
-*stackable* con `abstract override` (`abstract` no es necesario si el método
-que se redefine no es abstracto). En términos de diseño, este patrón es una
-implementación del patrón *Decorator*, pero por composición de **clases** en
-vez de composición de **objetos**.
+de declarar una subclase nueva por cada combinación. Un trait puede llamar a
+`super.metodo()` con un `override` normal si ese método ya es concreto en la
+cadena de supertipos *declarada* por el trait. Aquí no lo es: `Uppercase` y
+`WithSpaces` extienden `Writer`, que declara `print` como abstracto — así que
+hace falta `abstract override`, precisamente para poder compilar una llamada
+a `super.print` confiando en que, en tiempo de ejecución, la [*linearization*
+de clases](https://www.scala-lang.org/files/archive/spec/2.13/05-classes-and-objects.html#class-linearization)
+(el orden en que Scala resuelve `super` cuando se mezclan varios traits)
+habrá colocado antes una implementación concreta (la de `ConsoleWriter`,
+mezclada al construir el objeto). `abstract` no sería necesario si el trait
+extendiera directamente una clase con `print` ya concreto. En términos de
+diseño, este patrón es una implementación del patrón *Decorator*, pero por
+composición de **clases** en vez de composición de **objetos**.
 
 ## Implementación y diseño: rectángulos y cuadrados
 

--- a/slides/implementacion/oop.md
+++ b/slides/implementacion/oop.md
@@ -466,26 +466,26 @@ Un **trait** es una forma de separar las dos principales responsabilidades de un
 #### Ejemplo 2: Un iterador con Scala traits
 
 ```scala hl_lines="4"
-trait Iterator[A] {
-  def hasNext: Boolean
-  def next(): A
+trait Iterador[A] {
+  def haySiguiente: Boolean
+  def siguiente(): A
 }
 
-class IntIterator(to: Int) extends Iterator[Int] {
-  private var current = 0
-  override def hasNext: Boolean = current < to
-  override def next(): Int =  {
-    if (hasNext) {
-      val t = current
-      current += 1
+class IteradorEnteros(hasta: Int) extends Iterador[Int] {
+  private var actual = 0
+  override def haySiguiente: Boolean = actual < hasta
+  override def siguiente(): Int =  {
+    if (haySiguiente) {
+      val t = actual
+      actual += 1
       t
     } else 0
   }
 }
 
-val iterator = new IntIterator(10)
-println(iterator.next())  // prints 0
-println(iterator.next())  // prints 1
+val iterador = new IteradorEnteros(10)
+println(iterador.siguiente())  // prints 0
+println(iterador.siguiente())  // prints 1
 ```
 
 ---
@@ -829,7 +829,7 @@ public class Creador {
     PersonajeDeAccion[] x = {
       new PersonajeDeAccion(),
       new PersonajeDeAccion(),
-      new Heroe(),
+      new Heroe(), // Upcast implícito: se guarda como PersonajeDeAccion
       new PersonajeDeAccion()
     };
     return x;
@@ -847,7 +847,7 @@ public class Aventura {
   public static void main(String[] args) {
     PersonajeDeAccion[] cuatroFantasticos = new Creador().personajes();
     cuatroFantasticos[1].luchar();
-    cuatroFantasticos[2].luchar(); // Upcast
+    cuatroFantasticos[2].luchar(); // Ya es un PersonajeDeAccion (upcast al crearlo)
 
     // En tiempo de compilacion: metodo no encontrado:
     //! cuatroFantasticos[2].volar();
@@ -1072,14 +1072,14 @@ p {
 
 - Tipos **genéricos**
   - Ada
-  - C++ generics
-  - Java _templates_ (desde JDK 1.5)
+  - C++ _generics_ o _templates_
+  - Java _generics_ (desde JDK 1.5)
   - Scala
   - etc.
 
 - Diferencias entre lenguajes:
   - En C++, los genéricos permiten meta-programación en tiempo de compilación
-  - En Java, las plantillas son wrappers que _moldean_ objetos (_syntactic sugar_)
+  - En Java, los generics son wrappers que _moldean_ objetos (_syntactic sugar_)
   
 ---
 
@@ -1216,6 +1216,10 @@ object Test {
 }
 ```
 
+`writer3` y `writer4` producen el mismo resultado (`"A B C"`): mayúsculas y
+espaciado conmutan aquí. El problema no es el orden, sino la subclase extra
+que hace falta por cada combinación.
+
 ---
 
 ¿Y si aparece una nueva forma de imprimir?
@@ -1235,6 +1239,8 @@ class ChecksumWriter extends ConsoleWriter {
 ---
 
 #### Ejemplo: Herencia fuera de control
+
+_(Extrapolando cómo quedaría la jerarquía si se siguiera combinando_ `Uppercase`_,_ `WithSpaces` _y_ `Checksum` _entre sí)_
 
 @startuml
 
@@ -1326,9 +1332,9 @@ A B C
 
 ### Stackable traits
 
-- En Scala, los `trait` normales son como interfaces, se enlazan en tiempo de ejecución (no tienen acceso a `super`).
-- Se pueden redefinir [_stackable traits_](https://www.artima.com/articles/scalas-stackable-trait-pattern) con `abstract override` para dar acceso a `super`
-- `abstract` no es necesario si se redefine un método no abstracto, que ya tiene una implementación
+- Un trait puede llamar a `super.metodo()` con un `override` normal si ese método ya es concreto en la cadena de supertipos _declarada_ por el trait
+- Si el método es abstracto en esa cadena (como `Writer.print` aquí), hace falta `abstract override`: compila la llamada a `super` confiando en que, en tiempo de ejecución, la [_linearization_ de clases](https://www.scala-lang.org/files/archive/spec/2.13/05-classes-and-objects.html#class-linearization) (el orden en que Scala resuelve `super` al mezclar varios traits) habrá colocado antes una implementación concreta
+- Este patrón se llama [_stackable traits_](https://www.artima.com/articles/scalas-stackable-trait-pattern)
 - En diseño, son una implementación del patrón _Decorator_ pero por composición de clases en vez de por composición de objetos
 
 ---


### PR DESCRIPTION
## Resumen

Correcciones de contenido y terminología en el tema de Programación con objetos, en las slides Marp y en los apuntes Docusaurus generados a partir de ellas:

- Terminología: "Java templates" → "Java generics" (JDK 1.5 introdujo generics, no templates).
- Comentario de `// Upcast` movido al lugar donde realmente ocurre (al guardar un `Heroe` en un array `PersonajeDeAccion[]`), en vez de en la llamada a método posterior.
- Aclaración de que el diagrama UML de la jerarquía `Writer` extrapola combinaciones que no llegan a mostrarse en código.
- Aclaración de que `UppercaseWithSpacesWriter` y `WithSpacesUppercaseWriter` producen el mismo resultado (mayúsculas y espaciado conmutan en este ejemplo); el problema real es la explosión combinatoria de subclases, no el orden.
- Precisión sobre cuándo un trait de Scala necesita `abstract override` para llamar a `super` (cuando el método es abstracto en la cadena de supertipos declarada del trait), con enlace a la especificación oficial de Scala sobre *class linearization*.
- El trait de ejemplo `Iterator[A]` se renombra a `Iterador[A]` (y su método/parámetros al castellano) para no colisionar con `scala.Iterator` de la biblioteca estándar.

## Test plan

- [x] Slides reconstruidas a PDF con `marp/pdf-build.sh` y revisadas visualmente: ninguna de las slides modificadas se desborda del espacio 16:9.
- [x] Apuntes Docusaurus reconstruidos (`pnpm run build` en `site/`) sin errores.

🤖 Generado con Claude Code
